### PR TITLE
Changed not to look at file extension

### DIFF
--- a/spec/js/convert-to-img-tag-spec.js
+++ b/spec/js/convert-to-img-tag-spec.js
@@ -38,6 +38,19 @@ describe("convertToImgTag", function(){
       expect(result).toEqual(null)
     })
   }) 
+
+  describe('when text does not contain file extension', function () {
+    beforeEach(function () {
+      text = "hogehoge![title](https://user-images.githubusercontent.com/test0)\n \
+              hogehoge![title](https://img.esa.io/uploads/production/pictures/image/test1)"
+      result = convertToImgTag(text, "")
+    })
+    it('should return replaced text', function () {
+      text = "hogehoge<img src=https://user-images.githubusercontent.com/test0 >\n \
+              hogehoge<img src=https://img.esa.io/uploads/production/pictures/image/test1 >"
+      expect(result).toEqual(text)
+    })
+  }) 
 })
 
 describe("convertOnlySelectionToImgTag", function(){
@@ -213,13 +226,21 @@ describe('createMarkdownImages', function () {
       })
     })
   })
-  describe('when text contains only different extension', function () {
+  describe('when text does not contain file extension', function () {
     beforeEach(function () {
-      text = "hogehoge![title](https://user-images.githubusercontent.com/test.mp3)hogehoge"
+      text = "hogehoge![title](https://user-images.githubusercontent.com/test)hogehoge"
       result = createMarkdownImages(text, "")
     })
-    it('should return null ', function () {
-      expect(result).toEqual(null)
+    it('should match one md image ', function () {
+      let markdownImage = result[0]
+      let imageURL = "https://user-images.githubusercontent.com/test"
+      let imageTag = "<img src=https://user-images.githubusercontent.com/test >"
+      let mdImageText = "![title](https://user-images.githubusercontent.com/test)"
+
+      expect(result.length).toEqual(1)
+      expect(markdownImage.url).toEqual(imageURL)
+      expect(markdownImage.imageTag).toEqual(imageTag)
+      expect(markdownImage.mdImageText).toEqual(mdImageText)
     })
   })
   describe('when text contains md image', function () {

--- a/src/js/convert-to-img-tag.js
+++ b/src/js/convert-to-img-tag.js
@@ -60,11 +60,11 @@ function convertToImgTag(text, params) {
 
 function createMarkdownImages(text, params) {
   let markdownImageArray = []
-  const results = text.match(/\!\[.*?\]\(https:\S+?(jpg|jpeg|png|gif)\)/gmi)
+  const results = text.match(/\!\[.*?\]\(https:\S+?\)/gmi)
   if (results == null) { return null }
 
   for (const mdImage of results) {
-    const imageURL = mdImage.match(/https:\S+(jpg|jpeg|png|gif)/i)[0]
+    const imageURL = mdImage.match(/\((\S+)\)/i)[1]
     const imageTag = `<img src=${imageURL} ${params}>`
     const markdownImage = new MarkdownImage(imageURL, mdImage, imageTag)
     markdownImageArray.push(markdownImage)


### PR DESCRIPTION
Fix: https://github.com/funzin/ImgConverter/issues/36

Before: text must have file extension(e.g. jpg, png and so on)
After: text can be converted by markdown image structure(e.g. `![title](url)` is image structure) 